### PR TITLE
respect_cursor_position option

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -46,6 +46,20 @@
                   "platform": "Linux"
                 },
                 "caption": "Key Bindings – User"
+              },
+              {
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/Jump Along Indent/jump_along_indent.sublime-settings"
+                },
+                "caption": "Settings - Default"
+              },
+              {
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/User/jump_along_indent.sublime-settings"
+                },
+                "caption": "Settings - User"
               }
             ]
           }

--- a/file_scanner.py
+++ b/file_scanner.py
@@ -38,7 +38,11 @@ class FileScanner:
     return indent
 
   def search_str(self):
-    if re.match(r"^\s*$", self.str_to_left()) and re.match(r"^\s+\S+", self.str_to_right()):
+    settings = sublime.load_settings("jump_along_indent.sublime-settings")
+    respect_cursor_position = settings.get("respect_cursor_position")
+    between_leading_spaces = re.match(r"^\s*$", self.str_to_left()) and re.match(r"^\s+\S+", self.str_to_right())
+
+    if respect_cursor_position and between_leading_spaces:
       indent = self.adapt_indent(self.str_to_left())
       search_str = "^ {0," + str(indent) + "}\S+"
     else:

--- a/jump_along_indent.sublime-settings
+++ b/jump_along_indent.sublime-settings
@@ -1,0 +1,8 @@
+{
+	// By default, "Jump Along Indent" will take the indent before the cursor
+	// into account.
+	// If you want that the cursor position within the line doesn't play a role
+	// and instead always the full indent of the current line is relevant, set
+	// respect_cursor_position to false.
+	"respect_cursor_position" : true
+}

--- a/tests/test_jump_next_indent.py
+++ b/tests/test_jump_next_indent.py
@@ -1,4 +1,5 @@
 from helper import TestHelper
+import sublime
 
 class TestJumpNextIndent(TestHelper):
   def command(self):
@@ -115,3 +116,34 @@ class TestJumpNextIndent(TestHelper):
     ending_selection = [111, 85]
 
     self.check_command(lines, starting_selection, ending_selection, extend_selection = True)
+
+  def test_respect_cursor_position(self):
+
+    lines = [
+      '  Lorem ipsum dolor sit amet',
+      'Lorem ipsum dolor sit amet',
+      '  Lorem ipsum dolor sit amet'
+    ]
+
+    starting_selection = [0, 0]
+    ending_selection = [29, 29]
+
+    self.check_command(lines, starting_selection, ending_selection)
+
+  def test_disrespect_cursor_position(self):
+
+    settings = sublime.load_settings("jump_along_indent.sublime-settings")
+    settings.set("respect_cursor_position", False)
+
+    lines = [
+      '  Lorem ipsum dolor sit amet',
+      'Lorem ipsum dolor sit amet',
+      '  Lorem ipsum dolor sit amet'
+    ]
+
+    starting_selection = [0, 0]
+    ending_selection = [56, 56]
+
+    self.check_command(lines, starting_selection, ending_selection)
+
+    settings.set("respect_cursor_position", True)

--- a/tests/test_jump_prev_indent.py
+++ b/tests/test_jump_prev_indent.py
@@ -1,4 +1,5 @@
 from helper import TestHelper
+import sublime
 
 class TestJumpPrevIndent(TestHelper):
   def command(self):
@@ -114,3 +115,33 @@ class TestJumpPrevIndent(TestHelper):
 
     self.check_command(lines, starting_selection, ending_selection, extend_selection = True)
 
+  def test_respect_cursor_position(self):
+
+    lines = [
+      'Lorem ipsum dolor sit amet',
+      '  Lorem ipsum dolor sit amet',
+      '  Lorem ipsum dolor sit amet'
+    ]
+
+    starting_selection = [27, 27]
+    ending_selection = [0, 0]
+
+    self.check_command(lines, starting_selection, ending_selection)
+
+  def test_disrespect_cursor_position(self):
+
+    settings = sublime.load_settings("jump_along_indent.sublime-settings")
+    settings.set("respect_cursor_position", False)
+
+    lines = [
+      'Lorem ipsum dolor sit amet',
+      '  Lorem ipsum dolor sit amet',
+      '  Lorem ipsum dolor sit amet'
+    ]
+
+    starting_selection = [56, 56]
+    ending_selection = [27, 27]
+
+    self.check_command(lines, starting_selection, ending_selection)
+
+    settings.set("respect_cursor_position", True)


### PR DESCRIPTION
When jumping along indents, it can get a little bit annoying that the current cursor position within the line is taken into account. I know that this is a matter of taste, but personally, I prefer that the actual indent of the current line is deciding and not the amount of spaces before the cursor.

That's why I added a `respect_cursor_position` setting which is true by default (so, the existing default behavior is unchanged).

I added a describing comment to the sublime-settings file, but I don't know if it is very comprehensible. Feel free to improve it if you like.
